### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.3.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ It should contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 ### search

--- a/actions/search.yaml
+++ b/actions/search.yaml
@@ -1,6 +1,6 @@
 ---
 name: search
-runner_type: run-python
+runner_type: python-script
 description: Splunk one-shot search
 entry_point: search.py
 parameters:

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,6 +4,6 @@ name: splunk
 description: Splunk integration pack
 keywords:
   - splunk
-version : 0.3.0
+version : 0.4.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.