### PR TITLE
Removed unused version param

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.5.1
+
+- Removed unused `version` string from `config.schema.yaml
+ 
 ## 0.5.0
 
 - Update splunk.search to use splunklib.results.ResultsReader to return formatted results,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk Integration Pack
 
-Basic integration with Splunk Enterprise, Splunk Cloud, or Splunk Light: http://www.splunk.com/en\_us/products.html
+Basic integration with Splunk Enterprise, Splunk Cloud, or Splunk Light: http://www.splunk.com/en_us/products.html
 
 ## Configuration
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -26,9 +26,3 @@
     secret: false
     required: false
     default: "https"
-  version:
-    description: "Splunk API version"
-    type: "string"
-    secret: false
-    required: false
-    default: "5.0"

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,6 +4,6 @@ name: splunk
 description: Splunk integration pack
 keywords:
   - splunk
-version : 0.5.0
+version : 0.5.1
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/splunk.yaml.example
+++ b/splunk.yaml.example
@@ -4,4 +4,3 @@ port: 8089
 username: admin
 password: admin
 scheme: https
-version: '5.0'


### PR DESCRIPTION
The `version` param is not used anymore, so let's get rid of it from the config.