### PR TITLE
allows for ssl verification to be disabled #7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.6.0
+
+- Added the ability to disable SSL validation using `verify: false` in `splunk.yaml`
+
 ## 0.5.1
 
 - Removed unused `version` string from `config.schema.yaml

--- a/actions/search.py
+++ b/actions/search.py
@@ -18,7 +18,8 @@ class OneShotSearch(Action):
             port=self.config.get('port'),
             username=self.config.get('username'),
             password=self.config.get('password'),
-            scheme=self.config.get('scheme'))
+            scheme=self.config.get('scheme'),
+            verify=self.config.get('verify'))
 
     def run(self, query):
         result = self.service.jobs.oneshot(query, params={"output_mode": "json"})

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -26,3 +26,9 @@
     secret: false
     required: false
     default: "https"
+  verify:
+    description: "Check the validity of the SSL certificate returned by Splunk"
+    type: "boolean"
+    secret: false
+    required: false
+    default: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - splunk
   - monitoring
   - alerting
-version: 0.5.2
+version: 0.6.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/splunk.yaml.example
+++ b/splunk.yaml.example
@@ -4,3 +4,4 @@ port: 8089
 username: admin
 password: admin
 scheme: https
+verify: true


### PR DESCRIPTION
Small change to allow the action to connect to Splunk's API even if the certificate on tcp/8089 isn't trusted.
Defaults to requiring a valid certificate.